### PR TITLE
FileSystem: Remove redundant target-specific customization alert

### DIFF
--- a/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemConfiguration.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemConfiguration.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import {
-  Alert,
   Button,
   Checkbox,
   Content,
@@ -13,26 +12,20 @@ import { v4 as uuidv4 } from 'uuid';
 import FileSystemTable from './FileSystemTable';
 import PartitioningMode from './PartitioningMode';
 
-import {
-  FILE_SYSTEM_CUSTOMIZATION_URL,
-  targetOptions,
-} from '../../../../../constants';
+import { FILE_SYSTEM_CUSTOMIZATION_URL } from '../../../../../constants';
 import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
-import { ImageTypes } from '../../../../../store/imageBuilderApi';
 import {
   addPartition,
   changePartitioningMode,
   selectBlueprintMode,
   selectDiskPartitions,
   selectFilesystemPartitions,
-  selectImageTypes,
   selectPartitioningMode,
 } from '../../../../../store/wizardSlice';
 import UsrSubDirectoriesDisabled from '../../../UsrSubDirectoriesDisabled';
 import { getNextAvailableMountpoint } from '../fscUtilities';
 
 const FileSystemConfiguration = () => {
-  const environments = useAppSelector(selectImageTypes);
   const blueprintMode = useAppSelector(selectBlueprintMode);
   const filesystemPartitions = useAppSelector(selectFilesystemPartitions);
   const diskPartitions = useAppSelector(selectDiskPartitions);
@@ -57,17 +50,6 @@ const FileSystemConfiguration = () => {
       }),
     );
   };
-
-  const automaticPartitioningOnlyTargets: ImageTypes[] = [
-    'image-installer',
-    'wsl',
-  ];
-
-  const filteredTargets = (
-    automaticPartitioningOnlyTargets.filter((env) =>
-      environments.includes(env),
-    ) as ImageTypes[]
-  ).map((env) => targetOptions[env]);
 
   return (
     <>
@@ -100,16 +82,6 @@ const FileSystemConfiguration = () => {
           </Button>
         </Content>
       </Content>
-      {(environments.includes('image-installer') ||
-        environments.includes('wsl')) && (
-        <Alert
-          variant='warning'
-          isInline
-          title={`Filesystem customizations are not applied to ${filteredTargets.join(
-            ' and ',
-          )} images`}
-        />
-      )}
       <Checkbox
         label='Select partitioning mode'
         isChecked={partitioningMode !== undefined}


### PR DESCRIPTION
## Summary
- Removes the now-redundant filesystem customization warning alert ("Filesystem customizations are not applied to Bare metal - Installer images") from `FileSystemConfiguration.tsx`
- This alert is no longer needed since labels at the top of each step already indicate which customizations are supported for the selected targets
- Cleans up unused imports (`Alert`, `targetOptions`, `ImageTypes`, `selectImageTypes`) that were only used by the removed alert

## Test plan
- [ ] Verify the filesystem configuration step no longer shows the inline warning alert when "Bare metal - Installer" is selected as a target
- [ ] Verify the labels at the top of the step still correctly indicate target support/unsupport
- [ ] Confirm no regressions in filesystem partitioning functionality

Resolves: [HMS-10219](https://issues.redhat.com/browse/HMS-10219)